### PR TITLE
fix tab bug on ios on screen assigment

### DIFF
--- a/src/screens/AssignmentsScreen.jsx
+++ b/src/screens/AssignmentsScreen.jsx
@@ -512,18 +512,21 @@ const styles = StyleSheet.create({
   tabsGroup: {
     flexDirection: 'row',
     marginTop: 10,
+    justifyContent:'space-between'
   },
   tabButtonSelected: {
-    flex: 0.25,
+    flexGrow: 0.25,
     borderColor: Colors.primaryColor,
     borderWidth: 2,
     borderRadius: 5,
     paddingVertical: 5,
     marginHorizontal: 5,
     backgroundColor: Colors.primaryColor,
+    padding:10
   },
   tabButton: {
-    flex: 0.25,
+    padding:10,
+    flexGrow: 0.25,
     borderColor: Colors.primaryColor,
     borderWidth: 2,
     borderRadius: 5,


### PR DESCRIPTION
por alguna razon flex:0.25 funciona en IO, pero si flex-grow.  Con eso por lo menos ya mostraba el texto en los tabs. 
Agregue un padding porque en ios no se tiene un padding por default