### PR TITLE
event desc.: Show yearsAgoText not importantText

### DIFF
--- a/src/components/Reminders.jsx
+++ b/src/components/Reminders.jsx
@@ -154,9 +154,9 @@ const Reminders = ({ navigation, reminders }) => {
                       >
                         <View>
                           <Text style={styles.innerText}>{item.entityName}</Text>
-                          {item.importantText && (
+                          {item.yearsAgoText && (
                             <Text style={styles.reminderHeader}>
-                              {`${item.importantText.replace('%s', item.yearsAgo)} `}
+                              {`${item.yearsAgoText.replace('%s', item.yearsAgo)} `}
                             </Text>
                           )}
                         </View>


### PR DESCRIPTION
En vez de decir "48° aniversario de ordenación sacerdotal", puede decir más corto "48º aniversario".

Favor, prueba que funciona el cambio antes de merge.