### PR TITLE
use Checkbox from react-native-elements on ios dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,6 +1714,37 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/react": {
+      "version": "16.9.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+      "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.63.18",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.18.tgz",
+      "integrity": "sha512-WwEWqmHiqFn61M1FZR/+frj+E8e2o8i5cPqu9mjbjtZS/gBfCKVESF2ai/KAlaQECkkWkx/nMJeCc5eHMmLQgw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-native-vector-icons": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.5.tgz",
+      "integrity": "sha512-JBpcjWQE4n0GlE0p6HpDDclT+uXpFC453T5k4h+B38q0utlGJhvgNr8899BoJGc1xOktA2cgqFKmFMJd0h7YaA==",
+      "requires": {
+        "@types/react": "*",
+        "@types/react-native": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -2973,6 +3004,11 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
       "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg=="
+    },
+    "csstype": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
     },
     "damerau-levenshtein": {
       "version": "1.0.6",
@@ -7514,8 +7550,7 @@
     "opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-      "dev": true
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
     "optionator": {
       "version": "0.8.3",
@@ -8341,6 +8376,29 @@
         "use-subscription": "^1.0.0"
       }
     },
+    "react-native-elements": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-2.3.2.tgz",
+      "integrity": "sha512-HygYYmq8JYjk/YYiUwr/64qT64H2xlPBz0JnkGTQwvnnyXZrfkHFopw8rLWCupv3iLLPDzVohvPs0Z5HLdonSQ==",
+      "requires": {
+        "@types/react-native-vector-icons": "^6.4.5",
+        "color": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "hoist-non-react-statics": "^3.1.0",
+        "lodash.isequal": "^4.5.0",
+        "opencollective-postinstall": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-ratings": "^7.2.0",
+        "react-native-status-bar-height": "^2.5.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        }
+      }
+    },
     "react-native-gesture-handler": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.6.1.tgz",
@@ -8392,6 +8450,15 @@
       "resolved": "https://registry.npmjs.org/react-native-platform-touchable/-/react-native-platform-touchable-1.1.1.tgz",
       "integrity": "sha1-/eSsxl7qWF0osWTQw3FqQhKaaOQ="
     },
+    "react-native-ratings": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-7.3.0.tgz",
+      "integrity": "sha512-NCDIkmrVPnxPzP9zKdlcNpa2rPs3Hiv2qXsojUr3FpwbANWfgYE+jjGSSCBcS3vpXndTjhoaTGFDnybnUSFPFA==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-native-reanimated": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-1.9.0.tgz",
@@ -8424,6 +8491,11 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.9.0.tgz",
       "integrity": "sha512-5MaiUD6HA3nzY3JbVI8l3V7pKedtxQF3d8qktTVI0WmWXTI4QzqOU8r8fPVvfKo3MhOXwhWBjr+kQ7DZaIQQeg=="
+    },
+    "react-native-status-bar-height": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-status-bar-height/-/react-native-status-bar-height-2.5.0.tgz",
+      "integrity": "sha512-sYBCPYA/NapBSHkdm/IVL4ID3LLlIuLqINi2FBDyMkc2BU9pfSGOtkz9yfxoK39mYJuTrlTOQ7mManARUsYDSA=="
     },
     "react-native-svg": {
       "version": "9.13.6",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint --ext .jsx,.js src"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "2.4.0",
     "@react-native-community/masked-view": "0.1.10",
     "@use-expo/font": "^2.0.0",
     "axios": "^0.19.2",
@@ -17,6 +18,7 @@
     "expo-localization": "~8.2.1",
     "expo-network": "~2.2.1",
     "expo-permissions": "~9.0.1",
+    "expo-screen-orientation": "~1.1.1",
     "expo-vector-icons": "^10.0.1",
     "formik": "^2.1.4",
     "i18n-iso-countries": "^5.2.0",
@@ -30,6 +32,7 @@
     "react-dom": "16.11.0",
     "react-i18next": "^11.3.4",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz",
+    "react-native-elements": "^2.3.2",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-locale-detector": "^1.0.1",
     "react-native-paper": "^3.8.0",
@@ -39,16 +42,14 @@
     "react-native-screens": "~2.9.0",
     "react-native-svg-flagkit": "^0.9.5",
     "react-native-web": "~0.11.7",
+    "react-native-webview": "9.4.0",
     "react-navigation": "^4.3.7",
     "react-navigation-drawer": "^2.4.11",
     "react-navigation-header-buttons": "^3.0.5",
     "react-navigation-material-bottom-tabs": "^2.2.10",
     "react-navigation-stack": "^2.3.11",
     "react-navigation-tabs": "^2.8.11",
-    "yup": "^0.29.1",
-    "@react-native-community/datetimepicker": "2.4.0",
-    "react-native-webview": "9.4.0",
-    "expo-screen-orientation": "~1.1.1"
+    "yup": "^0.29.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/src/screens/SearchScreen.jsx
+++ b/src/screens/SearchScreen.jsx
@@ -168,10 +168,15 @@ class SearchScreen extends Component {
                     title={i18n.t('SEARCH.DECEASED')}
                     checked={this.state.showDeceased}
                     onPress={() => this.setState({ showDeceased: !this.state.showDeceased })}
-                    checkedColor="black"
-                    uncheckedIcon
-                    checkedIcon={<AntDesign name="checksquareo" size={24} color="black" />}
-                    uncheckedIcon={<MaterialCommunityIcons name="checkbox-blank-outline" size={24} color="black" />}
+                    checkedColor={Colors.onSurfaceColorPrimary}
+                    checkedIcon={<AntDesign name="checksquareo" size={24} color={Colors.onSurfaceColorPrimary} />}
+                    uncheckedIcon={
+                      <MaterialCommunityIcons
+                        name="checkbox-blank-outline"
+                        size={24}
+                        color={Colors.onSurfaceColorPrimary}
+                      />
+                    }
                   />
                   <CheckBox
                     textStyle={styles.textCheckBox}
@@ -179,10 +184,15 @@ class SearchScreen extends Component {
                     title={i18n.t('SEARCH.EX')}
                     checked={this.state.showExMember}
                     onPress={() => this.setState({ showExMember: !this.state.showExMember })}
-                    checkedColor="black"
-                    uncheckedIcon
-                    checkedIcon={<AntDesign name="checksquareo" size={24} color="black" />}
-                    uncheckedIcon={<MaterialCommunityIcons name="checkbox-blank-outline" size={24} color="black" />}
+                    checkedColor={Colors.onSurfaceColorPrimary}
+                    checkedIcon={<AntDesign name="checksquareo" size={24} color={Colors.onSurfaceColorPrimary} />}
+                    uncheckedIcon={
+                      <MaterialCommunityIcons
+                        name="checkbox-blank-outline"
+                        size={24}
+                        color={Colors.onSurfaceColorPrimary}
+                      />
+                    }
                   />
                 </Fragment>
               ) : (

--- a/src/screens/SearchScreen.jsx
+++ b/src/screens/SearchScreen.jsx
@@ -168,13 +168,12 @@ class SearchScreen extends Component {
                     title={i18n.t('SEARCH.DECEASED')}
                     checked={this.state.showDeceased}
                     onPress={() => this.setState({ showDeceased: !this.state.showDeceased })}
-                    checkedColor={Colors.onSurfaceColorPrimary}
-                    checkedIcon={<AntDesign name="checksquareo" size={24} color={Colors.onSurfaceColorPrimary} />}
+                    checkedIcon={<AntDesign name="checksquareo" size={24} color={Colors.primaryColor} />}
                     uncheckedIcon={
                       <MaterialCommunityIcons
                         name="checkbox-blank-outline"
                         size={24}
-                        color={Colors.onSurfaceColorPrimary}
+                        color={Colors.onSurfaceColorSecondary}
                       />
                     }
                   />
@@ -184,13 +183,12 @@ class SearchScreen extends Component {
                     title={i18n.t('SEARCH.EX')}
                     checked={this.state.showExMember}
                     onPress={() => this.setState({ showExMember: !this.state.showExMember })}
-                    checkedColor={Colors.onSurfaceColorPrimary}
-                    checkedIcon={<AntDesign name="checksquareo" size={24} color={Colors.onSurfaceColorPrimary} />}
+                    checkedIcon={<AntDesign name="checksquareo" size={24} color={Colors.primaryColor} />}
                     uncheckedIcon={
                       <MaterialCommunityIcons
                         name="checkbox-blank-outline"
                         size={24}
-                        color={Colors.onSurfaceColorPrimary}
+                        color={Colors.onSurfaceColorSecondary}
                       />
                     }
                   />

--- a/src/screens/SearchScreen.jsx
+++ b/src/screens/SearchScreen.jsx
@@ -1,5 +1,14 @@
 import React, { Component, Fragment } from 'react';
-import { View, Text, StyleSheet, TextInput, FlatList, TouchableOpacity, ActivityIndicator } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+  Platform,
+} from 'react-native';
 import Colors from '../constants/Colors';
 import { Ionicons } from 'expo-vector-icons';
 import { Checkbox } from 'react-native-paper';
@@ -9,6 +18,8 @@ import { Snackbar } from 'react-native-paper';
 import { HeaderButtons, Item } from 'react-navigation-header-buttons';
 import HeaderButton from '../components/HeaderButton';
 import { getPersons } from '../api';
+import { CheckBox } from 'react-native-elements';
+import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons';
 
 const styles = StyleSheet.create({
   screen: {
@@ -47,6 +58,16 @@ const styles = StyleSheet.create({
   },
   snackError: {
     backgroundColor: Colors.secondaryColor,
+  },
+  CheckBoxContainer: {
+    backgroundColor: 'transparent',
+    borderColor: 'transparent',
+    padding: 0,
+    marginLeft: 0,
+    marginRight: 0,
+  },
+  textCheckBox: {
+    fontFamily: 'work-sans',
   },
   option: {},
 });
@@ -139,23 +160,52 @@ class SearchScreen extends Component {
               <Ionicons name="ios-search" size={25} colors={Colors.primaryColor} />
             </View>
             <View style={styles.filtersContainer}>
-              <View style={styles.optionContainer}>
-                <Checkbox
-                  color={Colors.primaryColor}
-                  status={this.state.showDeceased ? 'checked' : 'unchecked'}
-                  onPress={() => this.setState({ showDeceased: !this.state.showDeceased })}
-                />
-                <Text style={styles.option}>{i18n.t('SEARCH.DECEASED')} </Text>
-              </View>
+              {Platform.OS === 'ios' ? (
+                <Fragment>
+                  <CheckBox
+                    textStyle={styles.textCheckBox}
+                    containerStyle={styles.CheckBoxContainer}
+                    title={i18n.t('SEARCH.DECEASED')}
+                    checked={this.state.showDeceased}
+                    onPress={() => this.setState({ showDeceased: !this.state.showDeceased })}
+                    checkedColor="black"
+                    uncheckedIcon
+                    checkedIcon={<AntDesign name="checksquareo" size={24} color="black" />}
+                    uncheckedIcon={<MaterialCommunityIcons name="checkbox-blank-outline" size={24} color="black" />}
+                  />
+                  <CheckBox
+                    textStyle={styles.textCheckBox}
+                    containerStyle={styles.CheckBoxContainer}
+                    title={i18n.t('SEARCH.EX')}
+                    checked={this.state.showExMember}
+                    onPress={() => this.setState({ showExMember: !this.state.showExMember })}
+                    checkedColor="black"
+                    uncheckedIcon
+                    checkedIcon={<AntDesign name="checksquareo" size={24} color="black" />}
+                    uncheckedIcon={<MaterialCommunityIcons name="checkbox-blank-outline" size={24} color="black" />}
+                  />
+                </Fragment>
+              ) : (
+                <Fragment>
+                  <View style={styles.optionContainer}>
+                    <Checkbox
+                      color={Colors.primaryColor}
+                      status={this.state.showDeceased ? 'checked' : 'unchecked'}
+                      onPress={() => this.setState({ showDeceased: !this.state.showDeceased })}
+                    />
+                    <Text style={styles.option}>{i18n.t('SEARCH.DECEASED')} </Text>
+                  </View>
 
-              <View style={styles.optionContainer}>
-                <Checkbox
-                  color={Colors.primaryColor}
-                  status={this.state.showExMember ? 'checked' : 'unchecked'}
-                  onPress={() => this.setState({ showExMember: !this.state.showExMember })}
-                />
-                <Text style={styles.option}>{i18n.t('SEARCH.EX')} </Text>
-              </View>
+                  <View style={styles.optionContainer}>
+                    <Checkbox
+                      color={Colors.primaryColor}
+                      status={this.state.showExMember ? 'checked' : 'unchecked'}
+                      onPress={() => this.setState({ showExMember: !this.state.showExMember })}
+                    />
+                    <Text style={styles.option}>{i18n.t('SEARCH.EX')} </Text>
+                  </View>
+                </Fragment>
+              )}
             </View>
 
             <FlatList


### PR DESCRIPTION
Utilize el CheckBox de la libreria react-native-element, en android se mantiene el uso del CheckBox de react-native-paper

before 
https://github.com/Guillecaba/fathersApp/issues/84

after
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-14 at 10 06 20](https://user-images.githubusercontent.com/12649261/93096088-f461aa00-f671-11ea-9843-40afb8262f9f.png)
