### PR TITLE
Fix show end date picker on android

### DIFF
--- a/src/screens/LivingSituations.jsx
+++ b/src/screens/LivingSituations.jsx
@@ -343,52 +343,27 @@ const LivingSituationsFormScreen = ({ navigation }) => {
                 {({ handleChange, values, handleSubmit, errors, setFieldValue }) => (
                   <>
                     <View>
-                      {
-                        // <DateTimePicker
-                        //   value={startDate ? new Date(startDate) : new Date()}
-                        //   mode="date"
-                        //   display="default"
-                        //   onChange={(event, selectedDate) => {
-                        //     setOpenStartDate(false);
-                        //     const dateFormated = formatDate(selectedDate);
-                        //     setFieldValue('startDate', dateFormated);
-                        //   }}
-                        // />
-                        <DateTimePickerModal
-                          isVisible={openStartDate}
-                          mode="date"
-                          onConfirm={(date) => {
-                            setOpenStartDate(false);
-                            const dateFormated = formatDate(date);
-                            setFieldValue('startDate', dateFormated);
-                          }}
-                          onCancel={() => setOpenStartDate(false)}
-                        />
-                      }
-                      {
-                        //   openEndDate && (
-                        //     <DateTimePicker
-                        //       value={endDate ? new Date(endDate) : new Date()}
-                        //       mode="date"
-                        //       display="default"
-                        //       onChange={(event, selectedDate) => {
-                        //         setOpenEndDate(false);
-                        //         const dateFormated = formatDate(selectedDate);
-                        //         setFieldValue('endDate', dateFormated);
-                        //       }}
-                        //     />
-                        //   )
-                        <DateTimePickerModal
-                          isVisible={openEndDate}
-                          mode="date"
-                          onConfirm={(date) => {
-                            setOpenEndDate(false);
-                            const dateFormated = formatDate(date);
-                            setFieldValue('endDate', dateFormated);
-                          }}
-                          onCancel={() => setOpenEndDate(false)}
-                        />
-                      }
+                      <DateTimePickerModal
+                        isVisible={openStartDate}
+                        mode="date"
+                        onConfirm={(date) => {
+                          setOpenStartDate(false);
+                          const dateFormated = formatDate(date);
+                          setFieldValue('startDate', dateFormated);
+                        }}
+                        onCancel={() => setOpenStartDate(false)}
+                      />
+                      <DateTimePickerModal
+                        isVisible={openEndDate}
+                        mode="date"
+                        onConfirm={(date) => {
+                          setOpenEndDate(false);
+                          const dateFormated = formatDate(date);
+                          setFieldValue('endDate', dateFormated);
+                        }}
+                        onCancel={() => setOpenEndDate(false)}
+                      />
+
                       {isCreate && (
                         <>
                           <Text style={styles.label}>{i18n.t('LIVING_SITUATION.FILIATION')}</Text>
@@ -489,16 +464,14 @@ const LivingSituationsFormScreen = ({ navigation }) => {
                     <View>
                       <Text style={styles.label}>{i18n.t('LIVING_SITUATION.END_DATE')}</Text>
                       <Button onPress={() => setOpenEndDate(true)}>
-                        <>
-                          <View style={styles.inputContainer}>
-                            <Text style={styles.inputDatePicker}>{_.get(values, 'endDate') || ''}</Text>
-                            <Ionicons name="ios-calendar" size={23} color={Colors.primaryColor} />
-                          </View>
-                          {errors && errors.endDate && (
-                            <Text style={styles.errorText}>{i18n.t('LIVING_SITUATION.ERROR_END_DATE')}</Text>
-                          )}
-                        </>
+                        <View style={styles.inputContainer}>
+                          <Text style={styles.inputDatePicker}>{_.get(values, 'endDate') || ''}</Text>
+                          <Ionicons name="ios-calendar" size={23} color={Colors.primaryColor} />
+                        </View>
                       </Button>
+                      {errors && errors.endDate && (
+                        <Text style={styles.errorText}>{i18n.t('LIVING_SITUATION.ERROR_END_DATE')}</Text>
+                      )}
                     </View>
 
                     <View>

--- a/src/screens/LivingSituations.jsx
+++ b/src/screens/LivingSituations.jsx
@@ -252,10 +252,11 @@ const LivingSituationsFormScreen = ({ navigation }) => {
     const year = selectedDate.getUTCFullYear();
     const month =
       selectedDate.getUTCMonth() + 1 < 10 ? `0${selectedDate.getUTCMonth() + 1}` : selectedDate.getUTCMonth() + 1;
-    const day = selectedDate.getUTCDate();
+    var day = selectedDate.getUTCDate();
+    // console.log('day.lenght ', length);
+    if (10-day>0)
+        day='0'+day
     const dateString = `${year}-${month}-${day}`;
-
-    console.log(selectedDate);
     console.log(dateString);
     return dateString;
   };
@@ -438,6 +439,7 @@ const LivingSituationsFormScreen = ({ navigation }) => {
                         style={{
                           inputAndroid: {
                             backgroundColor: Colors.surfaceColorSecondary,
+                            borderRadius: 10,
                           },
                           iconContainer: {
                             top: 10,


### PR DESCRIPTION
Encerrar con un tag vacio el ModalDatepicker y con el bloque error.endate no era suficiente. Movi el bloque dos jeraquias mas arriba en un view( acepta varios hijos) . Funciona y el mismo resultado