### PR TITLE
fix overlap of tabs button with the top of the scr

### DIFF
--- a/src/screens/AssignmentsScreen.jsx
+++ b/src/screens/AssignmentsScreen.jsx
@@ -27,6 +27,7 @@ import { NavigationEvents } from 'react-navigation';
 
 const styles = StyleSheet.create({
   screen: {
+    marginTop: 20,
     backgroundColor: Colors.surfaceColorPrimary,
     flex: 1,
     justifyContent: 'center',


### PR DESCRIPTION
Fix overlap of tabs buttons with the top of the screen on AssigmentScreen